### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete multi-character sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "vaul": "^1.1.2",
-    "zod": "^4.0.17"
+    "zod": "^4.0.17",
+    "sanitize-html": "^2.17.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import sanitizeHtml from 'sanitize-html';
 
 interface HashnodePost {
   id: string;
@@ -134,9 +135,8 @@ export async function GET() {
           
           mediumPosts.slice(0, 10).forEach((post: MediumItem, index: number) => {
             // Extract brief from content
-            const brief = post.description
-              ?.replace(/<[^>]*>/g, '') // Remove HTML tags
-              ?.substring(0, 200) + '...';
+            const brief = sanitizeHtml(post.description || '', { allowedTags: [], allowedAttributes: {} })
+              .substring(0, 200) + '...';
             
             posts.push({
               id: `medium-${index}-${post.link}`,


### PR DESCRIPTION
Potential fix for [https://github.com/IshaaqDaahir/portfolio/security/code-scanning/1](https://github.com/IshaaqDaahir/portfolio/security/code-scanning/1)

To robustly sanitize the `brief` extracted from the Medium post's description, the best fix is to use a well-tested library for HTML sanitization—such as `sanitize-html`. This library will remove all potentially dangerous tags (including `<script>`) and their attributes, and can be configured easily. Since the provided code is TypeScript in a Next.js API route, it's safe and standard to use external packages for such sanitization.

**Best way to fix:**
- Import the `sanitize-html` library.
- Use `sanitizeHtml(post.description, { allowedTags: [], allowedAttributes: {} })` to strip all HTML tags from input and return only plain text, replacing the current `.replace(/<[^>]*>/g, '')`.
- Optionally, if you want to allow some safe tags, configure the `allowedTags` array; but for plain text, the above configuration is best.
- Replace the existing brief extraction code in the map of Medium posts.
- Ensure `sanitize-html` is installed as a dependency.

**Required changes:**
- Add an import for `sanitize-html`.
- Update the sanitization logic for `brief` on/around line 137 to use `sanitizeHtml`.
- No additional methods or definitions required beyond the import and code edit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
